### PR TITLE
Feature/contain image and update zoom behavior to include entire container

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,17 @@ webpack config:
 | zoom-window-size | Number                                          | 2 | Zoom window size multiplier, relative with thumbnail size |
 | zoom-window-x | Number                                        | 300 | Location absolute on x-axis for zoom window |
 | zoom-window-y | Number                                        | 300 | Location absolute on y-axis for zoom window |
-| containImage | Boolean | false | option to contain the image, this uses `background-size: contain;`, instead of the default `background-size: cover;`
+| background-options | Object | DEFAULT_BACKGROUND_OPTIONS | options to create custom background, this automatically update the image size property to `background-size: contain;`, instead of the default `background-size: cover;`
+
+### DEFAULT_BACKGROUND_OPTIONS
+
+| Attribute   | Type      | Default              | Description                                              |
+| :---        | :---      | :---                 | :---                                                     |
+| image       | String    | 'none'               | Image url to be used as background                       |
+| color       | String    | '#fff'               | Color to be used in background, use any value compatible with `background-color` css property |
+| repeat      | Boolean   | false                | Option to repeat the background image                    |
+| size        | String    | '100%'               | Set the size of background image, use any value compatible with `background-size` css property |
+| position    | String    | 'top left'           | Set the position of background image, use any value compatible with `background-position` css property |
 
 ## Preview
 

--- a/README.md
+++ b/README.md
@@ -68,27 +68,33 @@ webpack config:
 
 ## Parameters
 
-| Attribute        | Type                                            | Default              | Description      |
-| :---             | :---:                                           | :---:                | :---             |
-| image            | String | - | Image to be displayed in thumbnail. Used also in the zoom if imageFull param is not given (required) |
-| image-full       | String                                          | ''       | Large version of image|
-| width           | Number                                           | 200 | Width of thumbnail in px|
-| height          | Number                                           | 200 | Height of thumbnail in px|
-| zoom-level      | Number                                           | 4 | Zoom level |
-| zoom-window-size | Number                                          | 2 | Zoom window size multiplier, relative with thumbnail size |
-| zoom-window-x | Number                                        | 300 | Location absolute on x-axis for zoom window |
-| zoom-window-y | Number                                        | 300 | Location absolute on y-axis for zoom window |
-| background-options | Object | DEFAULT_BACKGROUND_OPTIONS | options to create custom background, this automatically update the image size property to `background-size: contain;`, instead of the default `background-size: cover;`
+| Attribute          | Type      | Default     | Value | Description      |
+| :---               | :---:     | :---:       | :---  | :---             |
+| image              | String    | -           | -     | Image to be displayed in thumbnail. Used also in the zoom if imageFull param is not given (required) |
+| image-full         | String    | ''          | -     | Large version of image|
+| width              | Number    | 200         | -     | Width of thumbnail in px|
+| height             | Number    | 200         | -     | Height of thumbnail in px|
+| zoom-level         | Number    | 4           | -     | Zoom level |
+| zoom-window-size   | Number    | 2           | -     | Zoom window size multiplier, relative with thumbnail size |
+| zoom-window-x      | Number    | 300         | -     | Location absolute on x-axis for zoom window |
+| zoom-window-y      | Number    | 300         | -     | Location absolute on y-axis for zoom window |
+| background-options | Object    | null        | `BACKGROUND_OPTIONS object` or `{}` or `true` | Options to create custom background. Please refer to next section for available properties |
 
-### DEFAULT_BACKGROUND_OPTIONS
+### BACKGROUND_OPTIONS
 
-| Attribute   | Type      | Default              | Description                                              |
+| Properties   | Type      | Default              | Description                                              |
 | :---        | :---      | :---                 | :---                                                     |
 | image       | String    | 'none'               | Image url to be used as background                       |
 | color       | String    | '#fff'               | Color to be used in background, use any value compatible with `background-color` css property |
 | repeat      | Boolean   | false                | Option to repeat the background image                    |
 | size        | String    | '100%'               | Set the size of background image, use any value compatible with `background-size` css property |
 | position    | String    | 'top left'           | Set the position of background image, use any value compatible with `background-position` css property |
+
+Additional notes: 
+* You can specify truthy value to use default background options, such as
+`<vue-h-zoom background-options="true" />` or `<vue-h-zoom background-options="{}" />`
+* You only need to specify property (s) that you need, such as `<vue-h-zoom background-options="{ color: 'blue' }" />`
+* Using background-options automatically update the image size property to `background-size: contain;`, instead of the default `background-size: cover;`. This is done so that the background is also included in zoomed preview.
 
 ## Preview
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ webpack config:
 | zoom-window-size | Number                                          | 2 | Zoom window size multiplier, relative with thumbnail size |
 | zoom-window-x | Number                                        | 300 | Location absolute on x-axis for zoom window |
 | zoom-window-y | Number                                        | 300 | Location absolute on y-axis for zoom window |
+| containImage | Boolean | false | option to contain the image, this uses `background-size: contain;`, instead of the default `background-size: cover;`
 
 ## Preview
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-h-zoom",
   "description": "Native Vue Zoom images",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "author": {
     "name": "hidayat.febiansyah",
     "email": "hidayat.febiansyah@gdn-commerce.com"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-h-zoom",
   "description": "Native Vue Zoom images",
-  "version": "0.0.18",
+  "version": "0.1.0",
   "author": {
     "name": "hidayat.febiansyah",
     "email": "hidayat.febiansyah@gdn-commerce.com"

--- a/src/libs/vue-h-zoom.js
+++ b/src/libs/vue-h-zoom.js
@@ -79,7 +79,9 @@ export default {
     thumbnailStyle: function () {
       return {
         'background-image': `url(${this.image})`,
-        'background-size': 'cover',
+        'background-size': 'contain',
+        'background-repeat': 'no-repeat',
+        'background-position': '50% 50%',
         height: this.toPx(this.height),
         width: this.toPx(this.width)
       }
@@ -113,12 +115,16 @@ export default {
       return {
         'background-image': `url(${this.largeImage})`,
         'background-repeat': 'no-repeat',
-        'background-position': this.toPx(this.zoomPosX) + ' ' + this.toPx(this.zoomPosY),
-        'background-size': 'cover',
+        'background-position': '50% 50%',
+        'background-size': 'contain',
+        'background-color': '#fff',
         width: '100%',
         height: '100%',
         '-webkit-transform': `scale(${this.zoomLevel})`,
-        transform: `scale(${this.zoomLevel})`
+        transform: `
+          scale(${this.zoomLevel})
+          translate(${this.toPx(this.zoomPosX)}, ${this.toPx(this.zoomPosY)})
+        `
       }
     },
     pointerWidth: function () {

--- a/src/libs/vue-h-zoom.js
+++ b/src/libs/vue-h-zoom.js
@@ -155,7 +155,7 @@ export default {
     pointerBoxStyle: function () {
       return {
         position: 'absolute',
-        'z-index': '999',
+        'z-index': '2',
         transform: 'translateZ(0px)',
         top: this.toPx(this.pointerOffsetTop),
         left: this.toPx(this.pointerOffsetLeft),

--- a/src/libs/vue-h-zoom.js
+++ b/src/libs/vue-h-zoom.js
@@ -2,7 +2,7 @@ const DEFAULT_BACKGROUND_OPTIONS = {
   image: 'none',
   color: '#fff',
   repeat: false,
-  contain: true,
+  size: '100%',
   position: 'top left'
 }
 
@@ -41,9 +41,9 @@ export default {
       type: Number,
       default: 10
     },
-    backgroundOption: {
+    backgroundOptions: {
       type: Object,
-      default : () => DEFAULT_BACKGROUND_OPTIONS
+      default : null
     }
   },
   data () {
@@ -90,28 +90,30 @@ export default {
     },
     mainImgStyle: function () {
       return {
-        contain: 'contain',
+        contain: this.backgroundOptions ? 'contain' : 'cover',
         repeat: 'no-repeat',
         position: '50% 50%'
       }
     },
-    backgroundImgStyle: function () {
-      // style of background, will be visible if main image is contain
+    customBackgroundOptions: function () {
+      return this.backgroundOptions ? this.backgroundOptions : DEFAULT_BACKGROUND_OPTIONS
+    },
+    customBackgroundStyle: function () {
       return {
-        image: this.backgroundOption.image || DEFAULT_BACKGROUND_OPTIONS.image,
-        repeat: this.backgroundOption.repeat ? 'repeat' : 'no-repeat',
-        color: this.backgroundOption.color || DEFAULT_BACKGROUND_OPTIONS.color,
-        contain: this.backgroundOption.contain ? 'contain' : 'cover',
-        position: this.backgroundOption.position || DEFAULT_BACKGROUND_OPTIONS.position
+        image: this.customBackgroundOptions.image || DEFAULT_BACKGROUND_OPTIONS.image,
+        repeat: this.customBackgroundOptions.repeat ? 'repeat' : 'no-repeat',
+        color: this.customBackgroundOptions.color || DEFAULT_BACKGROUND_OPTIONS.color,
+        size: this.customBackgroundOptions.size || DEFAULT_BACKGROUND_OPTIONS.size,
+        position: this.customBackgroundOptions.position || DEFAULT_BACKGROUND_OPTIONS.position
       }
     },
     thumbnailStyle: function () {
       return {
-        'background-image': `url(${this.image}), url(${this.backgroundImgStyle.image})`,
-        'background-size': `${this.mainImgStyle.contain}, ${this.backgroundImgStyle.contain}`,
-        'background-repeat': `${this.mainImgStyle.repeat}, ${this.backgroundImgStyle.repeat}`,
-        'background-position': `${this.mainImgStyle.position}, ${this.backgroundImgStyle.position}`,
-        'background-color': this.backgroundImgStyle.color,
+        'background-image': `url(${this.image}), url(${this.customBackgroundStyle.image})`,
+        'background-size': `${this.mainImgStyle.contain}, ${this.customBackgroundStyle.size}`,
+        'background-repeat': `${this.mainImgStyle.repeat}, ${this.customBackgroundStyle.repeat}`,
+        'background-position': `${this.mainImgStyle.position}, ${this.customBackgroundStyle.position}`,
+        'background-color': this.customBackgroundStyle.color,
         height: this.toPx(this.height),
         width: this.toPx(this.width)
       }
@@ -143,11 +145,11 @@ export default {
     },
     zoomStyle: function () {
       return {
-        'background-image': `url(${this.largeImage}), url(${this.backgroundImgStyle.image})`,
-        'background-size': `${this.mainImgStyle.contain}, ${this.backgroundImgStyle.contain}`,
-        'background-repeat': `${this.mainImgStyle.repeat}, ${this.backgroundImgStyle.repeat}`,
-        'background-position': `${this.mainImgStyle.position}, ${this.backgroundImgStyle.position}`,
-        'background-color': this.backgroundImgStyle.color,
+        'background-image': `url(${this.largeImage}), url(${this.customBackgroundStyle.image})`,
+        'background-size': `${this.mainImgStyle.contain}, ${this.customBackgroundStyle.size}`,
+        'background-repeat': `${this.mainImgStyle.repeat}, ${this.customBackgroundStyle.repeat}`,
+        'background-position': `${this.mainImgStyle.position}, ${this.customBackgroundStyle.position}`,
+        'background-color': this.customBackgroundStyle.color,
         width: '100%',
         height: '100%',
         '-webkit-transform': `scale(${this.zoomLevel})`,

--- a/src/libs/vue-h-zoom.js
+++ b/src/libs/vue-h-zoom.js
@@ -43,7 +43,7 @@ export default {
     },
     backgroundOptions: {
       type: Object,
-      default : null
+      default: null
     }
   },
   data () {

--- a/src/libs/vue-h-zoom.js
+++ b/src/libs/vue-h-zoom.js
@@ -1,3 +1,11 @@
+const DEFAULT_BACKGROUND_OPTIONS = {
+  image: 'none',
+  color: '#fff',
+  repeat: false,
+  contain: true,
+  position: 'top left'
+}
+
 export default {
   name: 'vue-h-zoom',
   props: {
@@ -33,9 +41,9 @@ export default {
       type: Number,
       default: 10
     },
-    containImage: {
-      type: Boolean,
-      default: false
+    backgroundOption: {
+      type: Object,
+      default : () => DEFAULT_BACKGROUND_OPTIONS
     }
   },
   data () {
@@ -80,17 +88,30 @@ export default {
     zoomHeight: function () {
       return this.zoomWindowSize * this.height
     },
+    mainImgStyle: function () {
+      return {
+        contain: 'contain',
+        repeat: 'no-repeat',
+        position: '50% 50%'
+      }
+    },
+    backgroundImgStyle: function () {
+      // style of background, will be visible if main image is contain
+      return {
+        image: this.backgroundOption.image || DEFAULT_BACKGROUND_OPTIONS.image,
+        repeat: this.backgroundOption.repeat ? 'repeat' : 'no-repeat',
+        color: this.backgroundOption.color || DEFAULT_BACKGROUND_OPTIONS.color,
+        contain: this.backgroundOption.contain ? 'contain' : 'cover',
+        position: this.backgroundOption.position || DEFAULT_BACKGROUND_OPTIONS.position
+      }
+    },
     thumbnailStyle: function () {
-      return this.containImage ? {
-        'background-image': `url(${this.image})`,
-        'background-size': 'contain',
-        'background-repeat': 'no-repeat',
-        'background-position': '50% 50%',
-        height: this.toPx(this.height),
-        width: this.toPx(this.width)
-      } : {
-        'background-image': `url(${this.image})`,
-        'background-size': 'cover',
+      return {
+        'background-image': `url(${this.image}), url(${this.backgroundImgStyle.image})`,
+        'background-size': `${this.mainImgStyle.contain}, ${this.backgroundImgStyle.contain}`,
+        'background-repeat': `${this.mainImgStyle.repeat}, ${this.backgroundImgStyle.repeat}`,
+        'background-position': `${this.mainImgStyle.position}, ${this.backgroundImgStyle.position}`,
+        'background-color': this.backgroundImgStyle.color,
         height: this.toPx(this.height),
         width: this.toPx(this.width)
       }
@@ -121,12 +142,12 @@ export default {
       return posY
     },
     zoomStyle: function () {
-      return this.containImage ? {
-        'background-image': `url(${this.largeImage})`,
-        'background-repeat': 'no-repeat',
-        'background-position': '50% 50%',
-        'background-size': 'contain',
-        'background-color': '#fff',
+      return {
+        'background-image': `url(${this.largeImage}), url(${this.backgroundImgStyle.image})`,
+        'background-size': `${this.mainImgStyle.contain}, ${this.backgroundImgStyle.contain}`,
+        'background-repeat': `${this.mainImgStyle.repeat}, ${this.backgroundImgStyle.repeat}`,
+        'background-position': `${this.mainImgStyle.position}, ${this.backgroundImgStyle.position}`,
+        'background-color': this.backgroundImgStyle.color,
         width: '100%',
         height: '100%',
         '-webkit-transform': `scale(${this.zoomLevel})`,
@@ -134,15 +155,6 @@ export default {
           scale(${this.zoomLevel})
           translate(${this.toPx(this.zoomPosX)}, ${this.toPx(this.zoomPosY)})
         `
-      } : {
-        'background-image': `url(${this.largeImage})`,
-        'background-repeat': 'no-repeat',
-        'background-position': this.toPx(this.zoomPosX) + ' ' + this.toPx(this.zoomPosY),
-        'background-size': 'cover',
-        width: '100%',
-        height: '100%',
-        '-webkit-transform': `scale(${this.zoomLevel})`,
-        transform: `scale(${this.zoomLevel})`
       }
     },
     pointerWidth: function () {

--- a/src/libs/vue-h-zoom.js
+++ b/src/libs/vue-h-zoom.js
@@ -81,16 +81,18 @@ export default {
       return this.zoomWindowSize * this.height
     },
     thumbnailStyle: function () {
-      return {
+      return this.containImage ? {
+        'background-image': `url(${this.image})`,
+        'background-size': 'contain',
+        'background-repeat': 'no-repeat',
+        'background-position': '50% 50%',
+        height: this.toPx(this.height),
+        width: this.toPx(this.width)
+      } : {
         'background-image': `url(${this.image})`,
         'background-size': 'cover',
         height: this.toPx(this.height),
-        width: this.toPx(this.width),
-        ...(this.containImage && {
-          'background-size': 'contain',
-          'background-repeat': 'no-repeat',
-          'background-position': '50% 50%',
-        })
+        width: this.toPx(this.width)
       }
     },
     containerStyle: function () {
@@ -119,7 +121,20 @@ export default {
       return posY
     },
     zoomStyle: function () {
-      return {
+      return this.containImage ? {
+        'background-image': `url(${this.largeImage})`,
+        'background-repeat': 'no-repeat',
+        'background-position': '50% 50%',
+        'background-size': 'contain',
+        'background-color': '#fff',
+        width: '100%',
+        height: '100%',
+        '-webkit-transform': `scale(${this.zoomLevel})`,
+        transform: `
+          scale(${this.zoomLevel})
+          translate(${this.toPx(this.zoomPosX)}, ${this.toPx(this.zoomPosY)})
+        `
+      } : {
         'background-image': `url(${this.largeImage})`,
         'background-repeat': 'no-repeat',
         'background-position': this.toPx(this.zoomPosX) + ' ' + this.toPx(this.zoomPosY),
@@ -127,16 +142,7 @@ export default {
         width: '100%',
         height: '100%',
         '-webkit-transform': `scale(${this.zoomLevel})`,
-        transform: `scale(${this.zoomLevel})`,
-        ...(this.containImage && {
-          'background-position': '50% 50%',
-          'background-size': 'contain',
-          'background-color': '#fff',
-          transform: `
-            scale(${this.zoomLevel})
-            translate(${this.toPx(this.zoomPosX)}, ${this.toPx(this.zoomPosY)})
-          `
-        })
+        transform: `scale(${this.zoomLevel})`
       }
     },
     pointerWidth: function () {

--- a/src/libs/vue-h-zoom.js
+++ b/src/libs/vue-h-zoom.js
@@ -32,6 +32,10 @@ export default {
     zoomWindowY: {
       type: Number,
       default: 10
+    },
+    containImage: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -79,11 +83,14 @@ export default {
     thumbnailStyle: function () {
       return {
         'background-image': `url(${this.image})`,
-        'background-size': 'contain',
-        'background-repeat': 'no-repeat',
-        'background-position': '50% 50%',
+        'background-size': 'cover',
         height: this.toPx(this.height),
-        width: this.toPx(this.width)
+        width: this.toPx(this.width),
+        ...(this.containImage && {
+          'background-size': 'contain',
+          'background-repeat': 'no-repeat',
+          'background-position': '50% 50%',
+        })
       }
     },
     containerStyle: function () {
@@ -115,16 +122,21 @@ export default {
       return {
         'background-image': `url(${this.largeImage})`,
         'background-repeat': 'no-repeat',
-        'background-position': '50% 50%',
-        'background-size': 'contain',
-        'background-color': '#fff',
+        'background-position': this.toPx(this.zoomPosX) + ' ' + this.toPx(this.zoomPosY),
+        'background-size': 'cover',
         width: '100%',
         height: '100%',
         '-webkit-transform': `scale(${this.zoomLevel})`,
-        transform: `
-          scale(${this.zoomLevel})
-          translate(${this.toPx(this.zoomPosX)}, ${this.toPx(this.zoomPosY)})
-        `
+        transform: `scale(${this.zoomLevel})`,
+        ...(this.containImage && {
+          'background-position': '50% 50%',
+          'background-size': 'contain',
+          'background-color': '#fff',
+          transform: `
+            scale(${this.zoomLevel})
+            translate(${this.toPx(this.zoomPosX)}, ${this.toPx(this.zoomPosY)})
+          `
+        })
       }
     },
     pointerWidth: function () {

--- a/test/unit/vue-h-zoom.test.js
+++ b/test/unit/vue-h-zoom.test.js
@@ -113,13 +113,32 @@ describe('VueHZoom', () => {
       vm.width = 100
       const expected = {
         'background-image': `url(${vm.image})`,
+        'background-size': 'cover',
+        height: vm.toPx(1000),
+        width: vm.toPx(100)
+      }
+      assert.deepEqual(vm.thumbnailStyle, expected)
+    })
+    it('should have correct values when containImage prop is true', done => {
+      vm = new (Vue.extend(VueHZoom))({
+        propsData: {
+          image: '/abc.jpg',
+          containImage: true
+        }
+      })
+      vm.height = 1000
+      vm.width = 100
+      const expected = {
+        'background-image': `url(${vm.image})`,
         'background-size': 'contain',
         'background-repeat': 'no-repeat',
         'background-position': '50% 50%',
         height: vm.toPx(1000),
         width: vm.toPx(100)
       }
-      assert.deepEqual(vm.thumbnailStyle, expected)
+      nextTick(() => {
+        assert.deepEqual(vm.thumbnailStyle, expected)
+      }).then(done)
     })
   })
 
@@ -259,6 +278,43 @@ describe('VueHZoom', () => {
       const expected = {
         'background-image': `url(${vm.largeImage})`,
         'background-repeat': 'no-repeat',
+        'background-position': vm.toPx(posX) + ' ' + vm.toPx(posY),
+        'background-size': 'cover',
+        width: '100%',
+        height: '100%',
+        '-webkit-transform': `scale(${vm.zoomLevel})`,
+        transform: `scale(${vm.zoomLevel})`
+      }
+
+      assert.deepEqual(vm.zoomStyle, expected)
+    })
+
+    it('should calculate correctly when containImage prop is true', done => {
+      vm = new (Vue.extend(VueHZoom))({
+        propsData: {
+          image: '/abc.jpg',
+          containImage: true
+        }
+      })
+      vm.width = 400
+      vm.height = 500
+      vm.pointer = {
+        x: 200,
+        y: 300
+      }
+      vm.thumbnailPos = {
+        left: 50,
+        top: 100
+      }
+      vm.zoomWindowSize = 3
+      // the position of mouse, relative to the element, and multiply by window size, because it will be reflected
+      // in zoom window
+      const posX = -(200 - 50 - 200) * 3
+      const posY = -(300 - 100 - 250) * 3
+
+      const expected = {
+        'background-image': `url(${vm.largeImage})`,
+        'background-repeat': 'no-repeat',
         'background-position': '50% 50%',
         'background-size': 'cover',
         'background-size': 'contain',
@@ -271,8 +327,9 @@ describe('VueHZoom', () => {
           translate(${vm.toPx(vm.zoomPosX)}, ${vm.toPx(vm.zoomPosY)})
         `
       }
-
-      assert.deepEqual(vm.zoomStyle, expected)
+      nextTick(() => {
+        assert.deepEqual(vm.zoomStyle, expected)
+      }).then(done)
     })
   })
 

--- a/test/unit/vue-h-zoom.test.js
+++ b/test/unit/vue-h-zoom.test.js
@@ -113,7 +113,9 @@ describe('VueHZoom', () => {
       vm.width = 100
       const expected = {
         'background-image': `url(${vm.image})`,
-        'background-size': 'cover',
+        'background-size': 'contain',
+        'background-repeat': 'no-repeat',
+        'background-position': '50% 50%',
         height: vm.toPx(1000),
         width: vm.toPx(100)
       }
@@ -257,12 +259,17 @@ describe('VueHZoom', () => {
       const expected = {
         'background-image': `url(${vm.largeImage})`,
         'background-repeat': 'no-repeat',
-        'background-position': vm.toPx(posX) + ' ' + vm.toPx(posY),
+        'background-position': '50% 50%',
         'background-size': 'cover',
+        'background-size': 'contain',
+        'background-color': '#fff',
         width: '100%',
         height: '100%',
         '-webkit-transform': `scale(${vm.zoomLevel})`,
-        transform: `scale(${vm.zoomLevel})`
+        transform: `
+          scale(${vm.zoomLevel})
+          translate(${vm.toPx(vm.zoomPosX)}, ${vm.toPx(vm.zoomPosY)})
+        `
       }
 
       assert.deepEqual(vm.zoomStyle, expected)
@@ -292,7 +299,7 @@ describe('VueHZoom', () => {
       const left = 200 - (width / 2) - 50
       const expected = {
         position: 'absolute',
-        'z-index': '999',
+        'z-index': '2',
         transform: 'translateZ(0px)',
         top: vm.toPx(top),
         left: vm.toPx(left),

--- a/test/unit/vue-h-zoom.test.js
+++ b/test/unit/vue-h-zoom.test.js
@@ -107,38 +107,122 @@ describe('VueHZoom', () => {
     })
   })
 
+  describe('mainImgStyle', () => {
+    it('should have correct values when backgroundOptions is falsy', () => {
+      const expected = {
+        contain: 'cover',
+        repeat: 'no-repeat',
+        position: '50% 50%'
+      }
+      assert.deepEqual(vm.mainImgStyle, expected)
+    })
+
+    it('should have correct values when backgroundOptions is truthy', done => {
+      vm = new (Vue.extend(VueHZoom))({
+        propsData: {
+          image: '/abc.jpg',
+          backgroundOptions: true
+        }
+      })
+      const expected = {
+        contain: 'contain',
+        repeat: 'no-repeat',
+        position: '50% 50%'
+      }
+      nextTick(() => {
+        assert.deepEqual(vm.mainImgStyle, expected)
+      }).then(done)
+    })
+  })
+
+  describe('customBackgroundOptions', () => {
+    it('should have correct values when backgroundOptions is falsy', () => {
+      const expected = {
+        image: 'none',
+        color: '#fff',
+        repeat: false,
+        size: '100%',
+        position: 'top left'
+      }
+      assert.deepEqual(vm.customBackgroundOptions, expected)
+    })
+
+    it('should have correct values when backgroundOptions is truthy', done => {
+      vm = new (Vue.extend(VueHZoom))({
+        propsData: {
+          image: '/abc.jpg',
+          backgroundOptions: {
+            color: 'blue'
+          }
+        }
+      })
+      const expected = {
+        color: 'blue'
+      }
+      nextTick(() => {
+        assert.deepEqual(vm.customBackgroundOptions, expected)
+      }).then(done)
+    })
+  })
+
+  describe('customBackgroundStyle', () => {
+    it('should have correct values when backgroundOptions prop is truthy but has no properties', () => {
+      vm = new (Vue.extend(VueHZoom))({
+        propsData: {
+          image: '/abc.jpg',
+          backgroundOptions: {
+            image: '/asd.jpg',
+            repeat: true,
+            color: 'blue',
+            size: '50% 100%',
+            position: 'top left'
+          }
+        }
+      })
+      const expected = {
+        image: '/asd.jpg',
+        repeat: 'repeat',
+        color: 'blue',
+        size: '50% 100%',
+        position: 'top left'
+      }
+      assert.deepEqual(vm.customBackgroundStyle, expected)
+    })
+
+    it('should have correct values when backgroundOptions is truthy', done => {
+      vm = new (Vue.extend(VueHZoom))({
+        propsData: {
+          image: '/abc.jpg',
+          backgroundOptions: {}
+        }
+      })
+      const expected = {
+        image: 'none',
+        color: '#fff',
+        repeat: 'no-repeat',
+        size: '100%',
+        position: 'top left'
+      }
+      nextTick(() => {
+        assert.deepEqual(vm.customBackgroundStyle, expected)
+      }).then(done)
+    })
+  })
+
   describe('thumbnailStyle', () => {
     it('should have correct values', () => {
       vm.height = 1000
       vm.width = 100
       const expected = {
-        'background-image': `url(${vm.image})`,
-        'background-size': 'cover',
+        'background-image': `url(${vm.image}), url(${vm.customBackgroundStyle.image})`,
+        'background-size': `${vm.mainImgStyle.contain}, ${vm.customBackgroundStyle.size}`,
+        'background-repeat': `${vm.mainImgStyle.repeat}, ${vm.customBackgroundStyle.repeat}`,
+        'background-position': `${vm.mainImgStyle.position}, ${vm.customBackgroundStyle.position}`,
+        'background-color': vm.customBackgroundStyle.color,
         height: vm.toPx(1000),
         width: vm.toPx(100)
       }
       assert.deepEqual(vm.thumbnailStyle, expected)
-    })
-    it('should have correct values when containImage prop is true', done => {
-      vm = new (Vue.extend(VueHZoom))({
-        propsData: {
-          image: '/abc.jpg',
-          containImage: true
-        }
-      })
-      vm.height = 1000
-      vm.width = 100
-      const expected = {
-        'background-image': `url(${vm.image})`,
-        'background-size': 'contain',
-        'background-repeat': 'no-repeat',
-        'background-position': '50% 50%',
-        height: vm.toPx(1000),
-        width: vm.toPx(100)
-      }
-      nextTick(() => {
-        assert.deepEqual(vm.thumbnailStyle, expected)
-      }).then(done)
     })
   })
 
@@ -276,60 +360,21 @@ describe('VueHZoom', () => {
       const posY = -(300 - 100 - 250) * 3
 
       const expected = {
-        'background-image': `url(${vm.largeImage})`,
-        'background-repeat': 'no-repeat',
-        'background-position': vm.toPx(posX) + ' ' + vm.toPx(posY),
-        'background-size': 'cover',
-        width: '100%',
-        height: '100%',
-        '-webkit-transform': `scale(${vm.zoomLevel})`,
-        transform: `scale(${vm.zoomLevel})`
-      }
-
-      assert.deepEqual(vm.zoomStyle, expected)
-    })
-
-    it('should calculate correctly when containImage prop is true', done => {
-      vm = new (Vue.extend(VueHZoom))({
-        propsData: {
-          image: '/abc.jpg',
-          containImage: true
-        }
-      })
-      vm.width = 400
-      vm.height = 500
-      vm.pointer = {
-        x: 200,
-        y: 300
-      }
-      vm.thumbnailPos = {
-        left: 50,
-        top: 100
-      }
-      vm.zoomWindowSize = 3
-      // the position of mouse, relative to the element, and multiply by window size, because it will be reflected
-      // in zoom window
-      const posX = -(200 - 50 - 200) * 3
-      const posY = -(300 - 100 - 250) * 3
-
-      const expected = {
-        'background-image': `url(${vm.largeImage})`,
-        'background-repeat': 'no-repeat',
-        'background-position': '50% 50%',
-        'background-size': 'cover',
-        'background-size': 'contain',
-        'background-color': '#fff',
+        'background-image': `url(${vm.largeImage}), url(${vm.customBackgroundStyle.image})`,
+        'background-size': `${vm.mainImgStyle.contain}, ${vm.customBackgroundStyle.size}`,
+        'background-repeat': `${vm.mainImgStyle.repeat}, ${vm.customBackgroundStyle.repeat}`,
+        'background-position': `${vm.mainImgStyle.position}, ${vm.customBackgroundStyle.position}`,
+        'background-color': vm.customBackgroundStyle.color,
         width: '100%',
         height: '100%',
         '-webkit-transform': `scale(${vm.zoomLevel})`,
         transform: `
           scale(${vm.zoomLevel})
-          translate(${vm.toPx(vm.zoomPosX)}, ${vm.toPx(vm.zoomPosY)})
+          translate(${vm.toPx(posX)}, ${vm.toPx(posY)})
         `
       }
-      nextTick(() => {
-        assert.deepEqual(vm.zoomStyle, expected)
-      }).then(done)
+
+      assert.deepEqual(vm.zoomStyle, expected)
     })
   })
 


### PR DESCRIPTION
## Overview
This PR adds new background options feature, this allow users to use custom background for the image.
The current implementation of `background-size: cover;` css property will be replaced with 'background-size: contain` if background-options property is truthy

## Preview
Example of landscape image
![image](https://user-images.githubusercontent.com/24491284/96876104-3a483400-14a2-11eb-8e8f-d5fbc0a461d6.png)


Example of portrait image 
![image](https://user-images.githubusercontent.com/24491284/96876029-1edd2900-14a2-11eb-8996-d0bf937320fb.png)

* add new `background-option` prop to allow setting image or color as a background

Example of `background-option` usage
```vue
        <vue-h-zoom
          :image="'some-image-url'"
          :zoom-level="2"
          :height="400"
          :width="400"
          :zoom-window-size="1"
          :zoom-window-x="screenSize"
          :zoom-window-y="0"
          :background-option="{
            color: 'blue',
            image: 'https://mobileimages.lowes.com/product/converted/097518/097518281786.jpg'
          }"
        />
```

![image](https://user-images.githubusercontent.com/24491284/96999015-b607b680-155e-11eb-90b7-8ad1253021f9.png)

We can also combine color and image in the background using background-option
```vue
        <vue-h-zoom
          :image="'some-image-url'"
          :zoom-level="2"
          :height="400"
          :width="400"
          :zoom-window-size="1"
          :zoom-window-x="screenSize"
          :zoom-window-y="0"
          :background-option="{
            color: '#0095da',
            image: 'https://i.pinimg.com/600x315/c2/b1/4f/c2b14f9042ccd18e04318e5cb5b4b449.jpg',
            size: '50% 100%',
            repeat: false
          }"
        />
```
![image](https://user-images.githubusercontent.com/24491284/97133104-75d14f80-177b-11eb-8724-17f58e2df067.png)
